### PR TITLE
Fixed default button border on CustomButton

### DIFF
--- a/src/components/custom-button/custom-button.styles.jsx
+++ b/src/components/custom-button/custom-button.styles.jsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from "styled-components";
 
 const buttonStyles = css`
   background-color: black;
@@ -27,14 +27,17 @@ const invertedButtonStyles = css`
 const googleSignInStyles = css`
   background-color: #4285f4;
   color: white;
+  border: none;
 
   &:hover {
     background-color: #357ae8;
-    border: none;
   }
 `;
 
-const getButtonStyles = props => {
+const getButtonStyles = (props) => {
+  console.log(
+    `CustomButton -- isGoogleSignIn: ${props.isGoogleSignIn}, inverted: ${props.inverted}`
+  );
   if (props.isGoogleSignIn) {
     return googleSignInStyles;
   }
@@ -51,7 +54,7 @@ export const CustomButtonContainer = styled.button`
   padding: 0 35px 0 35px;
   font-size: 15px;
   text-transform: uppercase;
-  font-family: 'Open Sans Condensed';
+  font-family: "Open Sans Condensed";
   font-weight: bolder;
   cursor: pointer;
   display: flex;


### PR DESCRIPTION
With the change from SCSS to styled-components, the Google Sign In CustomButton rendered with the default button border on the outside. Changed styles to reflect original SCSS look. Also, this issue is in [the live version on Heroku](https://crwn-live.herokuapp.com/signin). Not super important, but just thought I'd point it out!